### PR TITLE
FIX: Workflow execution stays in running state

### DIFF
--- a/hello/hello-activity/Program.cs
+++ b/hello/hello-activity/Program.cs
@@ -84,7 +84,8 @@ namespace hello_workflow
                 var settings = new TemporalSettings("localhost:7233")
                 {
                     Namespace       = "test-namespace",
-                    CreateNamespace = true
+                    CreateNamespace = true,
+                    TaskQueue       = "hello-tasks"
                 };
 
                 using (var client = await TemporalClient.ConnectAsync(settings))

--- a/hello/hello-childworkflow/Program.cs
+++ b/hello/hello-childworkflow/Program.cs
@@ -84,7 +84,8 @@ namespace hello_workflow
                 var settings = new TemporalSettings("localhost:7233")
                 {
                     Namespace       = "test-namespace",
-                    CreateNamespace = true
+                    CreateNamespace = true,
+                    TaskQueue       = "hello-tasks"
                 };
 
                 using (var client = await TemporalClient.ConnectAsync(settings))

--- a/hello/hello-localactivity/Program.cs
+++ b/hello/hello-localactivity/Program.cs
@@ -84,7 +84,8 @@ namespace hello_workflow
                 var settings = new TemporalSettings("localhost:7233")
                 {
                     Namespace       = "test-namespace",
-                    CreateNamespace = true
+                    CreateNamespace = true,
+                    TaskQueue       = "hello-tasks"
                 };
 
                 using (var client = await TemporalClient.ConnectAsync(settings))

--- a/hello/hello-signal/Program.cs
+++ b/hello/hello-signal/Program.cs
@@ -91,7 +91,8 @@ namespace hello_workflow
                 var settings = new TemporalSettings("localhost:7233")
                 {
                     Namespace       = "test-namespace",
-                    CreateNamespace = true
+                    CreateNamespace = true,
+                    TaskQueue       = "hello-tasks"
                 };
 
                 using (var client = await TemporalClient.ConnectAsync(settings))

--- a/hello/hello-syncsignal/Program.cs
+++ b/hello/hello-syncsignal/Program.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // FILE:	    Main.cs
 // CONTRIBUTOR: Jeff Lill
 // COPYRIGHT:	Copyright (c) 2016-2019 by neonFORGE, LLC.  All rights reserved.
@@ -354,7 +354,8 @@ namespace hello_workflow
                 var settings = new TemporalSettings("localhost:7233")
                 {
                     Namespace       = "test-namespace",
-                    CreateNamespace = true
+                    CreateNamespace = true,
+                    TaskQueue       = "hello-tasks"
                 };
 
                 using (var client = await TemporalClient.ConnectAsync(settings))

--- a/hello/hello-syncsignal/Program.cs
+++ b/hello/hello-syncsignal/Program.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // FILE:	    Main.cs
 // CONTRIBUTOR: Jeff Lill
 // COPYRIGHT:	Copyright (c) 2016-2019 by neonFORGE, LLC.  All rights reserved.
@@ -205,7 +205,7 @@ namespace hello_workflow
     }
 
     [Workflow(AutoRegister = true)]
-    public class OrderWorkflow2 : WorkflowBase, IOrderWorkflow1
+    public class OrderWorkflow2 : WorkflowBase, IOrderWorkflow2
     {
         private enum OrderStatus
         {
@@ -383,7 +383,7 @@ namespace hello_workflow
                         //-------------------------------------
                         // Submit an order to: IOrderWorkflow2
 
-                        var stub2 = client.NewWorkflowStub<IOrderWorkflow1>();
+                        var stub2 = client.NewWorkflowStub<IOrderWorkflow2>();
                         var orderTask2 = stub2.ProcessAsync();
 
                         // Attempt to cancel it via a synchronous signal.

--- a/hello/hello-workflow/Program.cs
+++ b/hello/hello-workflow/Program.cs
@@ -67,7 +67,8 @@ namespace hello_workflow
                 var settings = new TemporalSettings("localhost:7233")
                 {
                     Namespace       = "test-namespace",
-                    CreateNamespace = true
+                    CreateNamespace = true,
+                    TaskQueue       = "hello-tasks"
                 };
 
                 using (var client = await TemporalClient.ConnectAsync(settings))


### PR DESCRIPTION
This PR, fixes:#1 by adding the TasQueue name (used by the Workflow) to be used on the worker.

